### PR TITLE
Fix the link at the top of the nav

### DIFF
--- a/src/layouts/index.html
+++ b/src/layouts/index.html
@@ -37,7 +37,7 @@
     <!-- Docs nav -->
     <div class="bs-docs-sidebar">
       <ul class="nav bs-docs-sidenav">
-        <li><h3 class="bs-docs-sidenav-heading"><a href="/" class="microcosm">Microcosm</a></h3></li>
+        <li><h3 class="bs-docs-sidenav-heading"><a href="{{ absURL "" }}" class="microcosm">Microcosm</a></h3></li>
 
         {{ template "docs/introduction/nav.html" . }}
 


### PR DESCRIPTION
As our base URL has a non-empty path, we need to use Hugo helpers to get an URL to the root of the site.

See: https://gohugo.io/functions/urls/absurl/#input-does-not-begin-with-a-slash